### PR TITLE
ノード追加処理の作成

### DIFF
--- a/web/actions/nodes/actions.ts
+++ b/web/actions/nodes/actions.ts
@@ -1,0 +1,275 @@
+"use server"
+
+import * as z from "zod"
+import {
+  AppActionError,
+  type ActionResponse,
+  mapUnknownToErrorResponse,
+} from "@/lib/errors"
+import prisma from "@/lib/prisma/client"
+import { createClient } from "@/lib/supabase/server"
+
+const MAX_ANSWER_LENGTH = 500
+const DEFAULT_ABSTRACT_QUESTION = "なぜそれをしていますか？"
+
+const addNodeSchema = z.object({
+  parentId: z.string().uuid().nullable(),
+  concreteAnswer: z.string().trim().min(1).max(MAX_ANSWER_LENGTH),
+  abstractAnswer: z.string().trim().max(MAX_ANSWER_LENGTH).optional(),
+})
+
+export type AddNodeInput = z.input<typeof addNodeSchema>
+
+export interface NodeResult {
+  id: string
+  parentId: string | null
+  concreteAnswer: string
+  abstractAnswer: string | null
+  realTags: string[]
+  emotionalTags: string[]
+  createdAt: string
+}
+
+export interface AddNodeResult {
+  node: NodeResult
+}
+
+export type AddNodeResponse = ActionResponse<AddNodeResult>
+
+const getUserTreeSchema = z.object({
+  rootId: z.string().uuid().optional(),
+})
+
+export type GetUserTreeInput = z.input<typeof getUserTreeSchema>
+
+export interface UserTreeNodeResult extends NodeResult {
+  depth: number
+}
+
+export interface GetUserTreeResult {
+  nodes: UserTreeNodeResult[]
+}
+
+export type GetUserTreeResponse = ActionResponse<GetUserTreeResult>
+
+/**
+ * Server Action: add a new node to the user's decision tree.
+ */
+export async function addNode(
+  rawInput: AddNodeInput
+): Promise<AddNodeResponse> {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) {
+      throw new AppActionError("UNAUTHORIZED", "認証が必要です。")
+    }
+
+    const parseResult = addNodeSchema.safeParse(rawInput)
+    if (!parseResult.success) {
+      throw new AppActionError("VALIDATION_ERROR", "入力値が不正です。")
+    }
+    const input = parseResult.data
+
+    if (input.parentId) {
+      const parentNode = await prisma.node.findUnique({
+        where: { id: input.parentId },
+        select: { userId: true },
+      })
+      if (!parentNode) {
+        throw new AppActionError("NODE_NOT_FOUND", "親ノードが見つかりません。")
+      }
+      if (parentNode.userId !== user.id) {
+        throw new AppActionError(
+          "FORBIDDEN",
+          "このノードへの操作は許可されていません。"
+        )
+      }
+    }
+
+    const node = await prisma.$transaction(async (tx) => {
+      const abstractQuestionDelegate = tx as unknown as {
+        abstractQuestion: {
+          create: (args: {
+            data: { question: string }
+            select: { id: true }
+          }) => Promise<{ id: string }>
+        }
+      }
+
+      const abstractQuestion =
+        await abstractQuestionDelegate.abstractQuestion.create({
+          data: {
+            question: DEFAULT_ABSTRACT_QUESTION,
+          },
+          select: { id: true },
+        })
+
+      return tx.node.create({
+        data: {
+          userId: user.id,
+          parentId: input.parentId ?? null,
+          abstractQuestionId: abstractQuestion.id,
+          concreteAnswer: input.concreteAnswer,
+          abstractAnswer: input.abstractAnswer ?? null,
+        } as never,
+      })
+    })
+
+    return {
+      node: {
+        id: node.id,
+        parentId: node.parentId,
+        concreteAnswer: node.concreteAnswer,
+        abstractAnswer: node.abstractAnswer,
+        realTags: node.realTags as string[],
+        emotionalTags: node.emotionalTags as string[],
+        createdAt: node.createdAt.toISOString(),
+      },
+    }
+  } catch (error) {
+    return mapUnknownToErrorResponse(error, "ノード処理に失敗しました。")
+  }
+}
+
+/**
+ * Server Action: get authenticated user's tree for AI question generation context.
+ * Uses Prisma only (no raw SQL) and returns nodes ordered by depth ASC, createdAt ASC.
+ */
+export async function getUserTree(
+  rawInput: GetUserTreeInput = {}
+): Promise<GetUserTreeResponse> {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      throw new AppActionError("UNAUTHORIZED", "認証が必要です。")
+    }
+
+    const parseResult = getUserTreeSchema.safeParse(rawInput)
+    if (!parseResult.success) {
+      throw new AppActionError("VALIDATION_ERROR", "入力値が不正です。")
+    }
+
+    const { rootId } = parseResult.data
+
+    const toResultNode = (
+      node: {
+        id: string
+        parentId: string | null
+        concreteAnswer: string
+        abstractAnswer: string | null
+        realTags: unknown
+        emotionalTags: unknown
+        createdAt: Date
+      },
+      depth: number
+    ): UserTreeNodeResult => ({
+      id: node.id,
+      parentId: node.parentId,
+      concreteAnswer: node.concreteAnswer,
+      abstractAnswer: node.abstractAnswer,
+      realTags: node.realTags as string[],
+      emotionalTags: node.emotionalTags as string[],
+      createdAt: node.createdAt.toISOString(),
+      depth,
+    })
+
+    const selection = {
+      id: true,
+      parentId: true,
+      concreteAnswer: true,
+      abstractAnswer: true,
+      realTags: true,
+      emotionalTags: true,
+      createdAt: true,
+    } as const
+
+    const nodes: UserTreeNodeResult[] = []
+
+    let currentLevel:
+      | Array<{
+          id: string
+          parentId: string | null
+          concreteAnswer: string
+          abstractAnswer: string | null
+          realTags: unknown
+          emotionalTags: unknown
+          createdAt: Date
+        }>
+      | undefined
+
+    if (rootId) {
+      const rootNode = await prisma.node.findUnique({
+        where: { id: rootId },
+        select: {
+          userId: true,
+          ...selection,
+        },
+      })
+
+      if (!rootNode) {
+        throw new AppActionError(
+          "NODE_NOT_FOUND",
+          "起点ノードが見つかりません。"
+        )
+      }
+
+      if (rootNode.userId !== user.id) {
+        throw new AppActionError(
+          "FORBIDDEN",
+          "このノードへの操作は許可されていません。"
+        )
+      }
+
+      currentLevel = [
+        {
+          id: rootNode.id,
+          parentId: rootNode.parentId,
+          concreteAnswer: rootNode.concreteAnswer,
+          abstractAnswer: rootNode.abstractAnswer,
+          realTags: rootNode.realTags,
+          emotionalTags: rootNode.emotionalTags,
+          createdAt: rootNode.createdAt,
+        },
+      ]
+    } else {
+      currentLevel = await prisma.node.findMany({
+        where: {
+          userId: user.id,
+          parentId: null,
+        },
+        orderBy: { createdAt: "asc" },
+        select: selection,
+      })
+    }
+
+    let depth = 0
+
+    while (currentLevel.length > 0) {
+      nodes.push(...currentLevel.map((node) => toResultNode(node, depth)))
+
+      const parentIds: string[] = currentLevel.map((node) => node.id)
+
+      currentLevel = await prisma.node.findMany({
+        where: {
+          userId: user.id,
+          parentId: { in: parentIds },
+        },
+        orderBy: { createdAt: "asc" },
+        select: selection,
+      })
+
+      depth += 1
+    }
+
+    return { nodes }
+  } catch (error) {
+    return mapUnknownToErrorResponse(error, "ノード処理に失敗しました。")
+  }
+}

--- a/web/app/(main)/(app)/add-node-test/page.tsx
+++ b/web/app/(main)/(app)/add-node-test/page.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import {
+  addNode,
+  getUserTree,
+  type AddNodeResponse,
+  type GetUserTreeResponse,
+} from "@/actions/nodes/actions"
+import { GraphTabBar } from "@/components/nav/tabbar"
+import { PageLayout } from "@/components/shared/page-layout"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+
+export default function AddNodeTestPage() {
+  const [rootId, setRootId] = useState("")
+  const [parentId, setParentId] = useState("")
+  const [concreteAnswer, setConcreteAnswer] = useState("")
+  const [abstractAnswer, setAbstractAnswer] = useState("")
+  const [addNodeResponse, setAddNodeResponse] =
+    useState<AddNodeResponse | null>(null)
+  const [getTreeResponse, setGetTreeResponse] =
+    useState<GetUserTreeResponse | null>(null)
+  const [isAddNodePending, startAddNodeTransition] = useTransition()
+  const [isGetTreePending, startGetTreeTransition] = useTransition()
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    startAddNodeTransition(async () => {
+      const result = await addNode({
+        parentId: parentId.trim() === "" ? null : parentId.trim(),
+        concreteAnswer,
+        abstractAnswer,
+      })
+      setAddNodeResponse(result)
+    })
+  }
+
+  const handleGetTree = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    startGetTreeTransition(async () => {
+      const result = await getUserTree({
+        rootId: rootId.trim() === "" ? undefined : rootId.trim(),
+      })
+      setGetTreeResponse(result)
+    })
+  }
+
+  return (
+    <PageLayout>
+      <div className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold tracking-tight">addNode 検証</h1>
+        <p className="text-sm text-muted-foreground">
+          Server Action `addNode` を直接実行して結果を確認します。
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>入力</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="parentId">parentId (UUID / 空でルート)</Label>
+              <Input
+                id="parentId"
+                placeholder="例: 8f07dfb5-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                value={parentId}
+                onChange={(event) => setParentId(event.target.value)}
+              />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="concreteAnswer">concreteAnswer</Label>
+              <Textarea
+                id="concreteAnswer"
+                value={concreteAnswer}
+                onChange={(event) => setConcreteAnswer(event.target.value)}
+                placeholder="今何をしていますか？"
+                rows={3}
+                required
+              />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="abstractAnswer">abstractAnswer</Label>
+              <Textarea
+                id="abstractAnswer"
+                value={abstractAnswer}
+                onChange={(event) => setAbstractAnswer(event.target.value)}
+                placeholder="なぜそれをしていますか？"
+                rows={3}
+              />
+            </div>
+
+            <Button type="submit" disabled={isAddNodePending}>
+              {isAddNodePending ? "実行中..." : "addNode 実行"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>addNode レスポンス</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <Separator />
+          <pre className="overflow-x-auto rounded-md bg-muted p-4 text-xs">
+            {addNodeResponse
+              ? JSON.stringify(addNodeResponse, null, 2)
+              : "ここにレスポンスが表示されます"}
+          </pre>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>getUserTree 入力</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="flex flex-col gap-4" onSubmit={handleGetTree}>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="rootId">rootId (UUID / 空で全体)</Label>
+              <Input
+                id="rootId"
+                placeholder="例: 8f07dfb5-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                value={rootId}
+                onChange={(event) => setRootId(event.target.value)}
+              />
+            </div>
+
+            <Button type="submit" disabled={isGetTreePending}>
+              {isGetTreePending ? "実行中..." : "getUserTree 実行"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>getUserTree レスポンス</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <Separator />
+          <pre className="overflow-x-auto rounded-md bg-muted p-4 text-xs">
+            {getTreeResponse
+              ? JSON.stringify(getTreeResponse, null, 2)
+              : "ここにレスポンスが表示されます"}
+          </pre>
+        </CardContent>
+      </Card>
+
+      <GraphTabBar />
+    </PageLayout>
+  )
+}

--- a/web/app/(main)/(onboarding)/onboarding/actions.ts
+++ b/web/app/(main)/(onboarding)/onboarding/actions.ts
@@ -1,51 +1,18 @@
 "use server"
 
-import { ZodError } from "zod"
-
 import {
   formSchema,
   type OnboardingFormInput,
 } from "@/lib/onboarding/form-schema"
+import { AppActionError, mapUnknownToAppActionError } from "@/lib/errors"
 import prisma from "@/lib/prisma/client"
 import { createClient } from "@/lib/supabase/server"
-
-class OnboardingActionError extends Error {
-  constructor(
-    public readonly code:
-      | "VALIDATION_ERROR"
-      | "UNAUTHORIZED"
-      | "PROFILE_NOT_FOUND"
-      | "INTERNAL_ERROR",
-    message: string
-  ) {
-    super(message)
-    this.name = "OnboardingActionError"
-  }
-}
 
 function normalizeInput(input: OnboardingFormInput) {
   return {
     concreteAnswer: input.present.trim(),
     abstractAnswer: input.reason?.trim() || null,
   }
-}
-
-function mapError(error: unknown): OnboardingActionError {
-  if (error instanceof OnboardingActionError) {
-    return error
-  }
-
-  if (error instanceof ZodError) {
-    return new OnboardingActionError(
-      "VALIDATION_ERROR",
-      "オンボーディング入力が不正です。"
-    )
-  }
-
-  return new OnboardingActionError(
-    "INTERNAL_ERROR",
-    "オンボーディングの保存に失敗しました。"
-  )
 }
 
 export async function submitOnboardingForm(data: unknown) {
@@ -59,7 +26,7 @@ export async function submitOnboardingForm(data: unknown) {
 
   if (!user) {
     console.warn("[onboarding] unauthorized access")
-    throw new OnboardingActionError("UNAUTHORIZED", "認証が必要です。")
+    throw new AppActionError("UNAUTHORIZED", "認証が必要です。")
   }
 
   try {
@@ -70,7 +37,7 @@ export async function submitOnboardingForm(data: unknown) {
       })
 
       if (!profile) {
-        throw new OnboardingActionError(
+        throw new AppActionError(
           "PROFILE_NOT_FOUND",
           "プロフィールが見つかりません。"
         )
@@ -119,7 +86,10 @@ export async function submitOnboardingForm(data: unknown) {
 
     return result
   } catch (error) {
-    const mappedError = mapError(error)
+    const mappedError = mapUnknownToAppActionError(
+      error,
+      "オンボーディングの保存に失敗しました。"
+    )
 
     console.error("[onboarding] failed", {
       userId: user.id,

--- a/web/lib/errors.ts
+++ b/web/lib/errors.ts
@@ -1,0 +1,70 @@
+import { ZodError } from "zod"
+
+export type AppErrorCode =
+  | "VALIDATION_ERROR"
+  | "UNAUTHORIZED"
+  | "NODE_NOT_FOUND"
+  | "FORBIDDEN"
+  | "PROFILE_NOT_FOUND"
+  | "INTERNAL_ERROR"
+
+export interface ErrorResponse {
+  error: {
+    code: AppErrorCode
+    message: string
+  }
+}
+
+export type ActionResponse<T> = T | ErrorResponse
+
+export class AppActionError extends Error {
+  constructor(
+    public readonly code: AppErrorCode,
+    message: string
+  ) {
+    super(message)
+    this.name = "AppActionError"
+  }
+}
+
+export function toErrorResponse(
+  code: AppErrorCode,
+  message: string
+): ErrorResponse {
+  return {
+    error: {
+      code,
+      message,
+    },
+  }
+}
+
+export function mapUnknownToErrorResponse(
+  error: unknown,
+  fallbackMessage: string
+): ErrorResponse {
+  if (error instanceof AppActionError) {
+    return toErrorResponse(error.code, error.message)
+  }
+
+  if (error instanceof ZodError) {
+    return toErrorResponse("VALIDATION_ERROR", "入力値が不正です。")
+  }
+
+  return toErrorResponse("INTERNAL_ERROR", fallbackMessage)
+}
+
+export function mapUnknownToAppActionError(
+  error: unknown,
+  fallbackMessage: string
+): AppActionError {
+  if (error instanceof AppActionError) {
+    return error
+  }
+
+  if (error instanceof ZodError) {
+    return new AppActionError("VALIDATION_ERROR", "入力値が不正です。")
+  }
+
+  return new AppActionError("INTERNAL_ERROR", fallbackMessage)
+}


### PR DESCRIPTION
- /web/actions/nodesにノード追加の処理を追加(addNode)
- 同様のファイルに再起クエリを使った木の取得関数(getUserTree)
- 検証用のテストページを追加(/add-node-test)
- エラーハンドリングや応答をプロジェクト内で共通化